### PR TITLE
Fixed error with multi-threading

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,0 +1,10 @@
+// mutex.h
+
+#ifndef MUTEX_H
+#define MUTEX_H
+
+#include <pthread.h>
+
+extern pthread_mutex_t terminal_mutex;
+
+#endif  // MUTEX_H

--- a/include/router.h
+++ b/include/router.h
@@ -43,7 +43,7 @@ enum request_method
  * @struct http_request
  * @brief Represents an HTTP request.
  */
-typedef struct http_request
+struct http_request
 {
     enum request_method method;  /**< The HTTP request method (e.g., GET, POST). */
     char path[100];              /**< The requested path in the URL. */
@@ -89,7 +89,7 @@ typedef int (*route_action)(int client_socket, struct http_request *http_request
  * HTTP request method, URL pattern, and a function pointer to the associated
  * route action.
  */
-typedef struct route
+struct route
 {
     const enum request_method method; /**< HTTP request method for the route. */
     const char *url;            /**< URL pattern associated with the route. */

--- a/include/router.h
+++ b/include/router.h
@@ -43,7 +43,7 @@ enum request_method
  * @struct http_request
  * @brief Represents an HTTP request.
  */
-struct http_request
+typedef struct http_request
 {
     enum request_method method;  /**< The HTTP request method (e.g., GET, POST). */
     char path[100];              /**< The requested path in the URL. */
@@ -89,9 +89,9 @@ typedef int (*route_action)(int client_socket, struct http_request *http_request
  * HTTP request method, URL pattern, and a function pointer to the associated
  * route action.
  */
-struct route
+typedef struct route
 {
-    enum request_method method; /**< HTTP request method for the route. */
+    const enum request_method method; /**< HTTP request method for the route. */
     const char *url;            /**< URL pattern associated with the route. */
     route_action action;        /**< Function pointer to the route action. */
 };
@@ -102,7 +102,7 @@ struct route
  * The `routes` is to be defined in another source file. It will be accessed by the route-handling
  * functions, providing information on available routes when trying to direct an HTTP request.
  */
-extern struct route routes[];
+extern const struct route routes[];
 
 /**
  * @brief Number of routes in the `routes` array.
@@ -111,7 +111,7 @@ extern struct route routes[];
  * route-handling functions, specifying the total number of routes available for
  * routing incoming HTTP requests.
  */
-extern size_t num_routes;
+extern const size_t num_routes;
 
 /**
  * @brief Parses a string representation of an HTTP request method and returns the corresponding enum value.

--- a/include/router.h
+++ b/include/router.h
@@ -12,8 +12,8 @@
 #define ROUTER_H
 
 #define MAX_REQUEST_BODY_LENGTH 4096
-#define RESPONSE_SUCCESS 0     /**< Constant indicating successful response. */
-#define RESPONSE_ERROR -1      /**< Constant indicating an error in response handling. */
+#define RESPONSE_SUCCESS 0 /**< Constant indicating successful response. */
+#define RESPONSE_ERROR -1  /**< Constant indicating an error in response handling. */
 
 #include <stdint.h>
 #include <stddef.h>
@@ -22,11 +22,12 @@ extern const char *response;
 
 /**
  * @brief Enum representing HTTP request methods.
- * 
+ *
  * This enumeration defines symbolic constants for HTTP request methods.
  *
  */
-enum request_method {
+enum request_method
+{
     GET,
     POST,
     PUT,
@@ -44,25 +45,25 @@ enum request_method {
  */
 struct http_request
 {
-    enum request_method method;              /**< The HTTP request method (e.g., GET, POST). */
-    char path[100];                          /**< The requested path in the URL. */
-    char version[10];                        /**< The HTTP protocol version (e.g., HTTP/1.1). */
-    char host[100];                          /**< The value of the Host header. */
-    char connection[20];                     /**< The value of the Connection header. */
-    char accept[200];                        /**< The value of the Accept header. */
-    char accept_encoding[100];               /**< The value of the Accept-Encoding header. */
-    char accept_language[100];               /**< The value of the Accept-Language header. */
-    char content_type[200];                  /**< The value of the Content-Type header. */
-    char cache_control[20];                  /**< The value of the Cache-Control header. */
-    char user_agent[200];                    /**< The value of the User-Agent header. */
-    char sec_ch_ua[100];                     /**< The value of the Sec-CH-UA header. */
-    char sec_ch_ua_mobile[20];               /**< The value of the Sec-CH-UA-Mobile header. */
-    char sec_ch_ua_platform[20];             /**< The value of the Sec-CH-UA-Platform header. */
-    char sec_fetch_site[20];                 /**< The value of the Sec-Fetch-Site header. */
-    char sec_fetch_mode[20];                 /**< The value of the Sec-Fetch-Mode header. */
-    char sec_fetch_dest[20];                 /**< The value of the Sec-Fetch-Dest header. */
-    char referer[100];                       /**< The value of the Referer header. */
-    char cookie[100];                        /**< The value of the Cookie header. */
+    enum request_method method;  /**< The HTTP request method (e.g., GET, POST). */
+    char path[100];              /**< The requested path in the URL. */
+    char version[10];            /**< The HTTP protocol version (e.g., HTTP/1.1). */
+    char host[100];              /**< The value of the Host header. */
+    char connection[20];         /**< The value of the Connection header. */
+    char accept[200];            /**< The value of the Accept header. */
+    char accept_encoding[100];   /**< The value of the Accept-Encoding header. */
+    char accept_language[100];   /**< The value of the Accept-Language header. */
+    char content_type[200];      /**< The value of the Content-Type header. */
+    char cache_control[20];      /**< The value of the Cache-Control header. */
+    char user_agent[200];        /**< The value of the User-Agent header. */
+    char sec_ch_ua[100];         /**< The value of the Sec-CH-UA header. */
+    char sec_ch_ua_mobile[20];   /**< The value of the Sec-CH-UA-Mobile header. */
+    char sec_ch_ua_platform[20]; /**< The value of the Sec-CH-UA-Platform header. */
+    char sec_fetch_site[20];     /**< The value of the Sec-Fetch-Site header. */
+    char sec_fetch_mode[20];     /**< The value of the Sec-Fetch-Mode header. */
+    char sec_fetch_dest[20];     /**< The value of the Sec-Fetch-Dest header. */
+    char referer[100];           /**< The value of the Referer header. */
+    char cookie[100];            /**< The value of the Cookie header. */
     char body[MAX_REQUEST_BODY_LENGTH];
 };
 
@@ -88,7 +89,8 @@ typedef int (*route_action)(int client_socket, struct http_request *http_request
  * HTTP request method, URL pattern, and a function pointer to the associated
  * route action.
  */
-struct route {
+struct route
+{
     enum request_method method; /**< HTTP request method for the route. */
     const char *url;            /**< URL pattern associated with the route. */
     route_action action;        /**< Function pointer to the route action. */
@@ -134,13 +136,16 @@ enum request_method parse_request_method(const char *method_string);
 struct http_request http_request_constructor(char *request_data);
 
 /**
- * @brief Handles an incoming client request.
+ * @brief Handles an HTTP request received from a client.
  *
- * This function reads the request from the client socket, processes it, and sends back a response via route functione and then closes the socket.
+ * Reads the HTTP request from the client socket, constructs an HTTP request struct,
+ * and then routes the request using the route function. Returns a dynamically allocated
+ * string describing the status of the connection. The caller is responsible for freeing the memory.
  *
- * @param client_socket The file descriptor of the client socket.
+ * @param client_socket The socket connected to the client.
+ * @return A dynamically allocated string describing the status of the connection. The caller is responsible for freeing the memory.
  */
-void handle_request(int client_socket);
+char *handle_request(int client_socket);
 
 /**
  * @brief Checks whether a given path matches a specified route pattern.
@@ -159,14 +164,17 @@ void handle_request(int client_socket);
 int is_route_matching(const char *pattern, const char *path);
 
 /**
- * @brief Routes the HTTP request to the appropriate handler.
+ * @brief Routes an HTTP request and sends a response to the client based on predefined routes.
  *
- * This function takes an HTTP request structure, determines the appropriate action based on the
- * request details, and sends the corresponding response back to the client.
+ * This function iterates through an array of routes, matches the HTTP request's method and path
+ * to a route, and executes the corresponding action. If no matching route is found, a default
+ * "404 Not Found" response is sent to the client. If the route action returns an error,
+ * a default "500 Internal server error" is sent to the client.
  *
- * @param http_request A pointer to the HTTP request structure.
- * @param client_socket The file descriptor of the client socket.
+ * @param http_request Pointer to the HTTP request struct.
+ * @param client_socket The socket connected to the client.
+ * @return A dynamically allocated string describing the status of the connection. The caller is responsible for freeing the memory.
  */
-void route(struct http_request *http_request, int client_socket);
+char *route(struct http_request *http_request, int client_socket);
 
 #endif

--- a/source/main.c
+++ b/source/main.c
@@ -28,7 +28,7 @@ pthread_mutex_t print_mutex = PTHREAD_MUTEX_INITIALIZER;
 /**
  * @brief Array of routes as availabled endpoints.
  */
-struct route routes[] = {
+const struct route routes[] = {
     {GET, "/", send_index_page},
     {GET, "/frida-kahlo", send_frida_page},
     {GET, "/jean-michel-basquiat", send_jean_page},
@@ -40,7 +40,7 @@ struct route routes[] = {
 /**
  * @brief Number of routes in the array.
  */
-size_t num_routes = sizeof(routes) / sizeof(routes[0]);
+const size_t num_routes = sizeof(routes) / sizeof(routes[0]);
 
 /**
  * @brief Handles the termination signal for graceful shutdown.
@@ -149,7 +149,7 @@ void handle_shutdown(int signum)
     printf("\nReceived termination signal. Initiating graceful shutdown...\n");
 
     shutdown_flag = 1;
-    
+
     if (global_server != NULL)
     {
         shutdown(global_server->socket, SHUT_RDWR);

--- a/source/route_actions.c
+++ b/source/route_actions.c
@@ -10,6 +10,7 @@
  */
 
 #include "route_actions.h"
+#include "mutex.h"
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -243,11 +244,9 @@ int send_json_response(int client_socket, const char *json, int status_code, con
         return RESPONSE_ERROR;
     }
 
-    // Create the response string
     snprintf(response, header_length + 1, response_format, status_code, status_phrase);
     strncat(response, json, response_length - header_length - 1); // Use strncat with proper size
 
-    // Write the response to the client socket
     if (write(client_socket, response, response_length - 1) < 0)
     {
         perror("Error writing to client");


### PR DESCRIPTION
Was due to how client socket was passed. It needed to be copied over and cast as an int not to be changed while thread process still was underway.